### PR TITLE
Bat updates

### DIFF
--- a/DRGModdingAutomationScripts/PrepModForRelease.bat
+++ b/DRGModdingAutomationScripts/PrepModForRelease.bat
@@ -4,13 +4,13 @@ setlocal EnableDelayedExpansion
 ::Set active directory to the dir the bat is in
 pushd %~dp0
 
-call UtilityBats/MakeDefaultConfigFiles.bat NoPause
+call UtilityBats/MakeDefaultConfigFiles.bat --noPause
 call UtilityBats/LoadVars.bat
-call UtilityBats/VerifyVars.bat noPause
+call UtilityBats/VerifyVars.bat --noPause
 
-call UtilityBats/CookUEProject.bat noPause
+call UtilityBats/CookUEProject.bat --noPause
 
-call UtilityBats/PackageMod.bat noPause
+call UtilityBats/PackageMod.bat --noPause
 
 cd Temp
 

--- a/DRGModdingAutomationScripts/PrepModForRelease.bat
+++ b/DRGModdingAutomationScripts/PrepModForRelease.bat
@@ -14,10 +14,10 @@ call UtilityBats/PackageMod.bat noPause
 
 cd Temp
 
-tar -a -cf %ModName%.zip %ModName%.pak
+tar -a -cf "%ModName%.zip" "%ModName%.pak"
 
 set /p ReleaseName=Please enter a suffix for this release:
 
-ren %ModName%.zip %ModName%%ReleaseName%.zip
+ren "%ModName%.zip" "%ModName%%ReleaseName%.zip"
 
 pause

--- a/DRGModdingAutomationScripts/QuickTestMod.bat
+++ b/DRGModdingAutomationScripts/QuickTestMod.bat
@@ -4,13 +4,13 @@ setlocal EnableDelayedExpansion
 ::Set active directory to the dir the bat is in
 pushd %~dp0
 
-call UtilityBats/MakeDefaultConfigFiles.bat NoPause
+call UtilityBats/MakeDefaultConfigFiles.bat --noPause
 call UtilityBats/LoadVars.bat
-call UtilityBats/VerifyVars.bat noPause
+call UtilityBats/VerifyVars.bat --noPause
 
-call UtilityBats/CookUEProject.bat noPause
+call UtilityBats/CookUEProject.bat --noPause
 
-call UtilityBats/PackageMod.bat noPause
+call UtilityBats/PackageMod.bat --noPause
 
 mkdir "%SteamInstall%\FSD\Mods\%ModName%"
 

--- a/DRGModdingAutomationScripts/UtilityBats/CookUEProject.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/CookUEProject.bat
@@ -18,7 +18,13 @@ if %errorlevel% gtr 0 (
 
 echo cooking complete
 
-::There's probably a better way to pass an argument to disable pausing, but Oh well
-if not "%1"=="noPause" (
+rem I found a better way to disable pausing :P
+set noPause=false
+for %%g in (%*) do (
+    if "%%g"=="--noPause" (
+        set noPause==true
+    )
+)
+if %noPause%==false (
 	pause
 )

--- a/DRGModdingAutomationScripts/UtilityBats/CopyWhitelistedFiles.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/CopyWhitelistedFiles.bat
@@ -21,7 +21,13 @@ for /F "tokens=*" %%g in (Configs/PakWhiteList.ini) do (
     )
 )
 
-::There's probably a better way to pass an argument to disable pausing, but Oh well
-if not "%1"=="noPause" (
+rem I found a better way to disable pausing :P
+set noPause=false
+for %%g in (%*) do (
+    if "%%g"=="--noPause" (
+        set noPause==true
+    )
+)
+if %noPause%==false (
 	pause
 )

--- a/DRGModdingAutomationScripts/UtilityBats/PackageMod.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/PackageMod.bat
@@ -5,8 +5,8 @@ rem Set active directory to main automation dir
 pushd %~dp0
 cd ..
 
-call UtilityBats/CopyWhitelistedFiles.bat noPause
-call UtilityBats/StripBlacklistedFiles.bat noPause
+call UtilityBats/CopyWhitelistedFiles.bat --noPause
+call UtilityBats/StripBlacklistedFiles.bat --noPause
 
 ::Make input text file
 echo making input text file

--- a/DRGModdingAutomationScripts/UtilityBats/PackageMod.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/PackageMod.bat
@@ -19,7 +19,13 @@ echo running UnrealPak
 
 echo Successfully packaged
 
-::There's probably a better way to pass an argument to disable pausing, but Oh well
-if not "%1"=="noPause" (
+rem I found a better way to disable pausing :P
+set noPause=false
+for %%g in (%*) do (
+    if "%%g"=="--noPause" (
+        set noPause==true
+    )
+)
+if %noPause%==false (
 	pause
 )

--- a/DRGModdingAutomationScripts/UtilityBats/StripBlacklistedFiles.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/StripBlacklistedFiles.bat
@@ -17,7 +17,13 @@ for /F "tokens=*" %%g in (Configs/PakBlackList.ini) do (
     )
 )
 
-::There's probably a better way to pass an argument to disable pausing, but Oh well
-if not "%1"=="noPause" (
+rem I found a better way to disable pausing :P
+set noPause=false
+for %%g in (%*) do (
+    if "%%g"=="--noPause" (
+        set noPause==true
+    )
+)
+if %noPause%==false (
 	pause
 )

--- a/DRGModdingAutomationScripts/UtilityBats/VerifyVars.bat
+++ b/DRGModdingAutomationScripts/UtilityBats/VerifyVars.bat
@@ -16,8 +16,14 @@ if not exist "%ProjectFolder%\%ProjectFile%" set err=1
 if %err%==1 GOTO errHandling
 
 
-rem There's probably a better way to pass an argument to disable pausing, but Oh well
-if not "%1"=="noPause" (
+rem I found a better way to disable pausing :P
+set noPause=false
+for %%g in (%*) do (
+    if "%%g"=="--noPause" (
+        set noPause==true
+    )
+)
+if %noPause%==false (
 	pause
 )
 exit /b


### PR DESCRIPTION
Minor fix for when mod names have a space in them

noPause is now --noPause, and is not required to be the first argument. (Tho since there's only ever one arg that shouldn't matter...)