### PR TITLE
Add Linux automation scripts

### DIFF
--- a/DRGModdingAutomationScriptsLinux/.env
+++ b/DRGModdingAutomationScriptsLinux/.env
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# /!\ All the paths should be absolute
+
+#################################################
+#                    PROJECT
+#################################################
+
+# -----------------------------------------------
+
+# Path to your UE4 installation
+# /!\ REQUIRED /!\
+UE4_PATH=""
+
+# -----------------------------------------------
+
+# Path to the Deep Rock Galactic steam folder
+# /!\ REQUIRED /!\
+DRG_PATH=""
+
+# -----------------------------------------------
+
+# Path to your mod project (the one containing the uproject file)
+# Defaults to the folder 'FSD' in the current directory
+#PROJECT_PATH=""
+
+# -----------------------------------------------
+
+# The name to use for the pak and zip
+# Defaults to the parent folder
+#MOD_NAME=""
+
+# -----------------------------------------------
+
+#################################################
+#                    WINE
+#################################################
+
+# -----------------------------------------------
+
+# Go to Lutris -> right click Epic Games Store then Configure
+# Go to the "Game options" tab and copy the content of the
+# "Wine prefix" field
+# This is important as it will allow wine to be in the same environnement as UE4
+# Defaults to your default wine prefix
+#export WINEPREFIX=""
+
+# -----------------------------------------------
+
+# Got to lutris, click on Epic Games Store
+# in the bottom click the Wine icon then "Open Bash terminal"
+# type 'echo $WINE' and paste the result here
+# This is important as it will allow to use the same wine version as the one used to run UE4
+# Defaults to wine
+#WINE=""
+
+# -----------------------------------------------
+
+#################################################
+#             DO NOT EDIT AFTER THIS
+#################################################
+
+
+# DEFAULT VALUES
+
+if [ -z ${WINE+x} ]; then
+    WINE="wine"
+fi
+
+if [ -z ${PROJECT_PATH+x} ]; then
+    PROJECT_PATH="$(pwd)/FSD"
+fi
+
+if [ -z ${MOD_NAME+x} ]; then
+    MOD_NAME="${PWD##/*/}"
+fi
+
+
+# ADDITIONAL VARIABLES
+
+# Unreal project file
+PROJECT_FILE="$PROJECT_PATH/FSD.uproject"
+# Disable Wine warnings to have clearer console output
+export WINEDEBUG=-all
+

--- a/DRGModdingAutomationScriptsLinux/README.md
+++ b/DRGModdingAutomationScriptsLinux/README.md
@@ -1,0 +1,32 @@
+# DRG modding automation scripts - Linux
+
+This repo contains various bash scripts to help you automate your projects, including packaging, zipping, cooking, and all those fun things.
+
+Those scripts were inspired by the [bat scripts](https://github.com/DRG-Modding/Useful-Scripts/tree/main/DRGModdingAutomationScripts) by Samamstar but do not work exactly the same, so be sure to read this documentation first!
+
+## Installation/usage
+
+In order to use this I recommend downloading the repo and placing it on folder above your .uproject. By default the scripts use the parent folder name as the mod name, and expects your .uproject parent folder to be named `FSD`.
+
+Imagine the following structure:
+
+- My Mod
+  - FSD
+    - FSD.uproject
+
+By placing the scripts under the `My Mod` folder, the project will be automatically detected and the scripts will use `My Mod` as the mod name.
+
+The most useful scripts are:
+
+- `quick_test_mod.sh`
+  - Automatically runs all steps required to test mod locally, by cooking the project, packing it, copying it into the local mods folder, and automatically launching DRG through Steam. Use the `-h` option to see how to skip a specific step.
+- `prep_mod_for_release.sh`
+  - Automatically runs all steps required to upload to mod.io, including cooking the project, packing it and zipping up the pak. Use the `-h` option to see how to skip a specific step.
+- `setup_cpp_project.sh`
+  - If UE4 gives an error when trying to open a project with C++ headers, try using this script.
+
+## Configuration
+
+All the configuration is done through environnement variables in the `.env`. Open it and read the comments for each variable to understand how to fill the right values.
+
+Some values are required, but some can be guessed from the folder in which the scripts are executed as explained in the `Installation/usage` section.

--- a/DRGModdingAutomationScriptsLinux/prep_mod_for_release.sh
+++ b/DRGModdingAutomationScriptsLinux/prep_mod_for_release.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+. ./.env
+
+DO_COOK=1
+DO_PACK=1
+
+Help()
+{
+   echo "Prepares the mod for release."
+   echo "Cooks and packs the mod, then creates a zip to be uploaded to mod.io."
+   echo
+   echo "Syntax: $0 [-h|c|p]"
+   echo "options:"
+   echo "h     Shows this help."
+   echo "c     Disable cooking."
+   echo "p     Disable packing."
+   echo
+}
+
+
+while getopts ":hcp" option; do
+    case $option in
+        h) # display Help
+            Help
+            exit;;
+        c) # Disable cooking
+            echo "Skipping cook phase"
+            DO_COOK=0;;
+        p) # Disable packing
+            echo "Skipping pack phase"
+            DO_PACK=0;;
+        \?) # Invalid option
+         echo "Error: Invalid option $option"
+         echo
+         Help
+         exit;;
+    esac
+done
+
+echo -e "\n-> Preparing mod for release\n"
+
+if [ $DO_COOK -ne 0 ]; then
+    ./util/cook_project.sh
+    COOK_ERROR=$?
+    if [ $COOK_ERROR -ne 0 ]; then
+        exit $COOK_ERROR
+    fi
+fi
+if [ $DO_PACK -ne 0 ]; then
+    ./util/pack_project.sh
+    PACK_ERROR=$?
+    if [ $PACK_ERROR -ne 0 ]; then
+        exit $PACK_ERROR
+    fi
+fi
+
+read -e -p "Please enter a suffix for this release: " RELEASE_SUFFIX
+
+echo "Zipping the mod"
+zip $MOD_NAME$RELEASE_SUFFIX.zip $MOD_NAME.pak
+
+echo -e "\n== Mod preparation done ==\n"
+

--- a/DRGModdingAutomationScriptsLinux/quick_test_mod.sh
+++ b/DRGModdingAutomationScriptsLinux/quick_test_mod.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+. ./.env
+
+
+DO_COOK=1
+DO_PACK=1
+DO_GAME=1
+
+Help()
+{
+   echo "Cooks and packs the mod, then installs it in DRG."
+   echo
+   echo "Syntax: $0 [-h|c|p|g]"
+   echo "options:"
+   echo "h     Shows this help."
+   echo "c     Disable cooking."
+   echo "p     Disable packing."
+   echo "g     Disable starting the game."
+   echo
+}
+
+
+while getopts ":hcpg" option; do
+    case $option in
+        h) # display Help
+            Help
+            exit;;
+        c) # Disable cooking
+            echo "Skipping cook phase"
+            DO_COOK=0;;
+        p) # Disable packing
+            echo "Skipping pack phase"
+            DO_PACK=0;;
+        g) # Disable starting the game
+            echo "Skipping game launching phase"
+            DO_GAME=0;;
+        \?) # Invalid option
+         echo "Error: Invalid option $option"
+         echo
+         Help
+         exit;;
+    esac
+done
+
+echo -e "\n-> Installing mod for testing\n"
+
+if [ $DO_COOK -ne 0 ]; then
+    ./util/cook_project.sh
+    COOK_ERROR=$?
+    if [ $COOK_ERROR -ne 0 ]; then
+        exit $COOK_ERROR
+    fi
+fi
+if [ $DO_PACK -ne 0 ]; then
+    ./util/pack_project.sh
+    PACK_ERROR=$?
+    if [ $PACK_ERROR -ne 0 ]; then
+        exit $PACK_ERROR
+    fi
+fi
+
+MOD_INSTALL_DIR="$DRG_PATH/FSD/Mods/$MOD_NAME"
+
+echo "Installing the mod"
+# Clean the folder to make sure only the mod is there
+rm -r "$MOD_INSTALL_DIR"
+mkdir -p "$MOD_INSTALL_DIR"
+cp "$MOD_NAME.pak" "$MOD_INSTALL_DIR"
+
+echo "Cleaning up after install"
+rm "$MOD_NAME.pak"
+
+echo -e "\n== Mod installation done ==\n"
+
+if [ $DO_GAME -ne 0 ]; then
+    echo -e "Starting DRG...\n"
+    steam steam://rungameid/548430
+fi

--- a/DRGModdingAutomationScriptsLinux/setup_cpp_project.sh
+++ b/DRGModdingAutomationScriptsLinux/setup_cpp_project.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. ./.env
+
+echo -e "\n-> Setting up EU4 project at '$PROJECT_FILE'\n"
+
+$WINE "$UE4_PATH/Engine/Binaries/DotNET/UnrealBuildTool.exe" -projectfiles -project="Z:$PROJECT_FILE" -game -rocket -progress
+
+echo -e "\n== Setting up EU4 project done ==\n"

--- a/DRGModdingAutomationScriptsLinux/util/cook_project.sh
+++ b/DRGModdingAutomationScriptsLinux/util/cook_project.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. ./.env
+
+echo -e "\n-> Cooking EU4 project at '$PROJECT_FILE'\n"
+
+$WINE "$UE4_PATH/Engine/Binaries/Win64/UE4Editor-Cmd.exe" "Z:$PROJECT_FILE" -run=cook -targetplatform=WindowsNoEditor
+
+WINE_ERROR=$?
+
+if [ $WINE_ERROR -ne 0 ]; then
+    echo -e "\n-x Error while cooking the project\n"
+    exit $WINE_ERROR
+fi
+
+echo -e "\n== Cooking EU4 project done ==\n"

--- a/DRGModdingAutomationScriptsLinux/util/pack_project.sh
+++ b/DRGModdingAutomationScriptsLinux/util/pack_project.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+. ./.env
+
+# VARIABLES SETUP -------------------------------
+
+BAKED_PATH="$PROJECT_PATH/Saved/Cooked/WindowsNoEditor/FSD"
+# Temporary folders used to pack the mod
+TMP_WORKSPACE="$(pwd)/.tmp_pack"
+TMP_WORKSPACE_INPUT="$TMP_WORKSPACE/input"
+# Utility to convert Linux path to Windows
+WINEPATH="$WINE"path
+# Wine path to the resulting pak file
+PAK_PATH="Z:$(pwd)/$MOD_NAME.pak"
+# Wine path to the autogen file
+AUTOGEN_PATH="Z:$TMP_WORKSPACE/autogen.txt"
+
+# -----------------------------------------------
+
+echo -e "\n-> Packing mod into $MOD_NAME.pak\n"
+
+echo "Cleaning previous temporary directory"
+rm -r "$TMP_WORKSPACE"
+mkdir -p "$TMP_WORKSPACE"
+
+echo "Copying assets to pack in temporary directory"
+mkdir -p "$TMP_WORKSPACE_INPUT"
+cp -r "$BAKED_PATH/Content" "$TMP_WORKSPACE_INPUT"
+cp "$BAKED_PATH/AssetRegistry.bin" "$TMP_WORKSPACE_INPUT"
+
+echo "Packing the mod"
+echo "$($WINEPATH -w "$TMP_WORKSPACE_INPUT/*")" "../../../FSD/" > "$TMP_WORKSPACE/autogen.txt"
+
+$WINE "$UE4_PATH/Engine/Binaries/Win64/UnrealPak.exe" "$PAK_PATH" -create="$AUTOGEN_PATH" -platform="Windows" -compress
+
+WINE_ERROR=$?
+
+echo "Cleaning up temporary directory after pack"
+rm -r "$TMP_WORKSPACE"
+
+if [ $WINE_ERROR -ne 0 ]; then
+    echo -e "\n-x Error while cooking the project\n"
+    exit $WINE_ERROR
+fi
+
+
+echo -e "\n== Packing done ==\n"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ If you are a member of the org, please make a folder to categorise what your scr
 * [Asset Generator](https://github.com/DRG-Modding/Useful-Scripts/tree/main/Asset%20Generator) - Written by Buckminsterfullerene
 * [Auto-rename Jukebox Songs](https://github.com/DRG-Modding/Useful-Scripts/tree/main/Auto-rename%20Jukebox%20Songs) - Written by Earthcomputer
 * [DRG Modding Automation Scripts](https://github.com/DRG-Modding/Useful-Scripts/tree/main/DRGModdingAutomationScripts) - Written by Samamstar
+* [DRG Modding Automation Scripts Linux](https://github.com/DRG-Modding/Useful-Scripts/tree/main/DRGModdingAutomationScriptsLinux) - Written by Keplyx
 * [Empty Content Hierarchy Generator](https://github.com/DRG-Modding/Useful-Scripts/tree/main/Empty%20Content%20Hierarchy%20Generator) - Written by Elythnwaen
 * [Soundclass Hierarchy Scripts](https://github.com/DRG-Modding/Useful-Scripts/tree/main/Soundclass%20Hierarchy) - Written by Buckminsterfullerene & Earthcomputer
 * [Sound Classes Plugin](https://github.com/DRG-Modding/Useful-Scripts/tree/main/Soundclass%20Hierarchy/TheSoundClassers) - Written by Hax


### PR DESCRIPTION
Adds some automation bash scripts, taking much inspiration on the bat from Samamstar.

They can cook, pak, zip and launch the game. They can also setup UE4 projects with cpp headers in case the editor fails to do so (can happen because it is a bit buggy on Wine).

Will get referenced in the Linux guide: https://mod.io/g/drg/r/drg-modding-tools-linux

Go to the readme for more info.